### PR TITLE
HF Downloads - Hacky fix

### DIFF
--- a/src/abbfn2/utils/inference_utils.py
+++ b/src/abbfn2/utils/inference_utils.py
@@ -382,6 +382,9 @@ def load_params(cfg: DictConfig) -> dict[str, jax.Array]:
         dict[str, jax.Array]: The parameters.
     """
     if cfg.load_from_hf:
+        dummy_config_path = hf_hub_download(
+            repo_id="InstaDeepAI/AbBFN2", filename="config.json"
+        )
         file_path = hf_hub_download(
             repo_id="InstaDeepAI/AbBFN2", filename="model_params.pkl"
         )


### PR DESCRIPTION
Preferred fix: #3 

Not ready for merge as I haven't pushed a dummy config.json to the AbBFN2 HF repo.

## Alternative (hacky) solution for download counting - Potential easy fix for ProtBFN HF.
Hugging Face tracks downloads based on the presence of a `config.json` file, even if no Hugging Face library code is used.  
See: [HF documentation](https://huggingface.co/docs/hub/en/models-download-stats)

However, there are reported issues with this approach:  
https://discuss.huggingface.co/t/huggingface-model-downloads-are-not-counted/108436
